### PR TITLE
feat: Make datetime and timestamp support microsecond for improving precision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+
+.PHONY: build-dev
+build-dev:
+	maturin develop --uv
+
+
+.PHONY: test
+test:
+	pytest tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl PyUlid {
 
     pub fn timestamp(&self) -> PyResult<f64> {
         let datetime: DateTime<Utc> = self.0.datetime().into();
-        Ok(datetime.timestamp() as f64)
+        Ok(datetime.timestamp_micros() as f64 / 1_000_000.0)
     }
 
     pub fn datetime<'p>(&self, _py: Python<'p>) -> PyResult<Bound<'p, PyDateTime>> {
@@ -45,7 +45,7 @@ impl PyUlid {
             datetime.hour() as u8,
             datetime.minute() as u8,
             datetime.second() as u8,
-            datetime.nanosecond(),
+            datetime.timestamp_subsec_micros(),
             None,
         )
     }
@@ -103,7 +103,7 @@ fn from_datetime(_py: Python, value: &Bound<PyDateTime>) -> PyResult<PyUlid> {
         let dt = Utc
             .with_ymd_and_hms(year, month, day, hour, minute, second)
             .unwrap()
-            .with_nanosecond(microsecond)
+            .with_nanosecond(microsecond * 1000)
             .unwrap();
         let system_time = dt.into();
         let ulid = Ulid::from_datetime(system_time);

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -32,7 +32,8 @@ def test_from_string():
     print(py_ulid.bytes())
     assert py_ulid.bytes() == b"\x01h\xd3\xff\x00\xcf\x86Y\xad\xd4\x9a\x16\xd3i\xc5\xff"
     assert py_ulid.randomness() == 634451394732979059803647
-    assert py_ulid.timestamp() == 1549744931.0
+    assert py_ulid.timestamp() == 1549744931.023
+    assert py_ulid.datetime() == datetime(2019, 2, 9, 20, 42, 11, 23000)
     assert py_ulid.str() == "01D39ZY06FGSCTVN4T2V9PKHFZ"
     assert py_ulid.increment().str() == "01D39ZY06FGSCTVN4T2V9PKHG0"
 
@@ -61,10 +62,10 @@ def test_from_timestamp():
 
 
 def test_from_datetime():
-    datetime_value = datetime(2023, 7, 28, hour=1, minute=20, tzinfo=timezone.utc)
+    datetime_value = datetime(2023, 7, 28, hour=1, minute=20, second=30, microsecond=123000, tzinfo=timezone.utc)
     py_ulid = from_datetime(datetime_value)
     assert py_ulid.str()
-    assert py_ulid.datetime() == datetime(2023, 7, 28, hour=1, minute=20)
+    assert py_ulid.datetime() == datetime(2023, 7, 28, hour=1, minute=20, second=30, microsecond=123000)
     assert py_ulid.timestamp() == datetime_value.timestamp()
 
 


### PR DESCRIPTION
- Updated timestamp handling in PyUlid to use microseconds for improved precision. 
- Introduced a Makefile with targets for building the development environment and running tests.
- Modified test cases to reflect changes in timestamp and datetime handling.